### PR TITLE
Shortcode

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -119,7 +119,7 @@ func (c *Cli) LongDescription(longdescription string) *Cli {
 	return c
 }
 
-// OtherArgs - Returns the non-flag arguments passed to the cli
+// OtherArgs - Returns the non-flag arguments passed to the cli. NOTE: This should only be called within the context of an action.
 func (c *Cli) OtherArgs() []string {
 	return c.rootCommand.flags.Args()
 }

--- a/cli.go
+++ b/cli.go
@@ -113,9 +113,24 @@ func (c *Cli) Action(callback Action) *Cli {
 	return c
 }
 
+// FlagShortCut  creates a shortcut or shorter call to a flags (i.e. "-readfiles" or "-rf")
+func (c *Cli) FlagShortCut(flagLongName string, flagShortCut string) *Cli {
+	var newFlagDetails flagDetails
+	newFlagDetails.flagName = flagLongName
+	newFlagDetails.shortCut = flagShortCut
+	c.rootCommand.flagList = append(c.rootCommand.flagList, newFlagDetails)
+	return c
+}
+
+// CommandShortCut creates a shortcut or shorter call to a command (i.e. "readfiles" or "rf")
+func (c *Cli) CommandShortCut(shortcut string) *Cli {
+	c.rootCommand.shortCut = shortcut
+	return c
+}
+
 // LongDescription - Sets the long description for the command
 func (c *Cli) LongDescription(longdescription string) *Cli {
-	c.rootCommand.LongDescription(longdescription)
+	c.rootCommand.longdescription = longdescription
 	return c
 }
 

--- a/cli.go
+++ b/cli.go
@@ -130,7 +130,7 @@ func (c *Cli) CommandShortCut(shortcut string) *Cli {
 
 // LongDescription - Sets the long description for the command
 func (c *Cli) LongDescription(longdescription string) *Cli {
-	c.rootCommand.longdescription = longdescription
+	c.rootCommand.LongDescription(longdescription)
 	return c
 }
 

--- a/command.go
+++ b/command.go
@@ -75,6 +75,7 @@ func (c *Command) parseFlags(args []string) error {
 
 // Run - Runs the Command with the given arguments
 func (c *Command) run(args []string) error {
+
 	// If we have arguments, process them
 	if len(args) > 0 {
 		// Convert command shortCut to full command name

--- a/command.go
+++ b/command.go
@@ -246,11 +246,10 @@ func (c *Command) IntFlag(name, description string, variable *int) *Command {
 
 // FlagShortCut  creates a shortcut or shorter call to a flags (i.e. "-readfiles" or "-rf")
 func (c *Command) FlagShortCut(flagLongName string, flagShortCut string) *Command {
-	for _, singleFlag := range c.flagList {
-		if singleFlag.flagName == flagLongName {
-			singleFlag.shortCut = flagShortCut
-		}
-	}
+	var newFlagDetails flagDetails
+	newFlagDetails.flagName = flagLongName
+	newFlagDetails.shortCut = flagShortCut
+	c.flagList = append(c.flagList, newFlagDetails)
 	return c
 }
 

--- a/command.go
+++ b/command.go
@@ -22,7 +22,6 @@ type Command struct {
 	flagCount         int
 	helpFlag          bool
 	hidden            bool
-	required          bool //the command/subcommand is required
 }
 
 // NewCommand creates a new Command
@@ -177,11 +176,6 @@ func (c *Command) isHidden() bool {
 // Hidden hides the command from the Help system
 func (c *Command) Hidden() {
 	c.hidden = true
-}
-
-// Required makes the command a required element
-func (c *Command) Required() {
-	c.required = true
 }
 
 // NewSubCommand - Creates a new subcommand

--- a/command.go
+++ b/command.go
@@ -22,6 +22,7 @@ type Command struct {
 	flagCount         int
 	helpFlag          bool
 	hidden            bool
+	required          bool //the command/subcommand is required
 }
 
 // NewCommand creates a new Command
@@ -178,6 +179,11 @@ func (c *Command) Hidden() {
 	c.hidden = true
 }
 
+// Required makes the command a required element
+func (c *Command) Required() {
+	c.required = true
+}
+
 // NewSubCommand - Creates a new subcommand
 func (c *Command) NewSubCommand(name, description string) *Command {
 	result := NewCommand(name, description)
@@ -222,4 +228,9 @@ func (c *Command) IntFlag(name, description string, variable *int) *Command {
 func (c *Command) LongDescription(longdescription string) *Command {
 	c.longdescription = longdescription
 	return c
+}
+
+// OtherArgs - Returns the non-flag arguments passed to the subcommand. NOTE: This should only be called within the context of an action.
+func (c *Command) OtherArgs() []string {
+	return c.flags.Args()
 }

--- a/command.go
+++ b/command.go
@@ -184,9 +184,21 @@ func (c *Command) PrintHelp() {
 		c.flags.SetOutput(os.Stdout)
 		c.flags.PrintDefaults()
 		c.flags.SetOutput(os.Stderr)
+		fmt.Println()
 
+		// If flags have shortcuts assigned print out the shortcuts
+		for _, flagDetails := range c.flagList {
+			if flagDetails.shortCut != "" {
+				fmt.Println("Flag Shortcuts:")
+				fmt.Println()
+				for _, flag := range c.flagList {
+					spacer := strings.Repeat(" ", 5)
+					fmt.Printf(" %s%s%s \n", "-"+flag.flagName, spacer, "-"+flag.shortCut)
+				}
+				fmt.Println()
+			}
+		}
 	}
-	fmt.Println()
 }
 
 // isDefaultCommand returns true if called on the default command

--- a/examples/otherargs/main.go
+++ b/examples/otherargs/main.go
@@ -24,6 +24,12 @@ func main() {
 		fmt.Printf("The remaining arguments were: %+v\n", cli.OtherArgs())
 		return nil
 	})
+	// Using a subcommand instead of a flag
+	nameCommand := cli.NewSubCommand("namecommand", "Shows your name!")
+	nameCommand.Action(func() error {
+		fmt.Printf("The remaining arguments were: %+v\n", nameCommand.OtherArgs())
+		return nil
+	})
 
 	// Run!
 	cli.Run()

--- a/examples/shortcut/main.go
+++ b/examples/shortcut/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/leaanthony/clir"
+)
+
+func main() {
+
+	// Create new cli
+	cli := clir.NewCli("Other Args", "A basic example", "v0.0.1")
+
+	// Set long description
+	cli.LongDescription("This app shows positional arguments")
+
+	// Name
+	var name string
+	nameFlag := cli.StringFlag("name", "Your name", &name)
+	// FlagShort is used to set a shortcut for a flag. Create a shortcut for "-name", that will be "-n"
+	nameFlag.FlagShortCut("name", "n")
+	// Define action
+	cli.Action(func() error {
+		println("Your name is", name)
+		fmt.Printf("The remaining arguments were: %+v\n", cli.OtherArgs())
+		return nil
+	})
+	// Using a subcommand instead of a flag
+	nameCommand := cli.NewSubCommand("namecommand", "Shows your name!")
+	// CommandShortCut is used to set a shortcut for a command. Create a shortcut for "namecommand" that will be "nc"
+	nameCommand.CommandShortCut("nc")
+	nameCommand.Action(func() error {
+		fmt.Printf("The remaining arguments were: %+v\n", nameCommand.OtherArgs())
+		return nil
+	})
+
+	// Run!
+	cli.Run()
+
+}

--- a/examples/shortcut/main.go
+++ b/examples/shortcut/main.go
@@ -32,6 +32,13 @@ func main() {
 		fmt.Println("The `namecommand` command was run!")
 		return nil
 	})
+	var newName string
+	newNameFlag := nameCommand.StringFlag("newname", "New Name", &newName)
+	newNameFlag.FlagShortCut("newname", "nn")
+	newNameFlag.Action(func() error {
+		fmt.Println("The flag `newname` was parsed!")
+		return nil
+	})
 
 	// Run!
 	cli.Run()

--- a/examples/shortcut/main.go
+++ b/examples/shortcut/main.go
@@ -9,10 +9,10 @@ import (
 func main() {
 
 	// Create new cli
-	cli := clir.NewCli("Other Args", "A basic example", "v0.0.1")
+	cli := clir.NewCli("Shortcuts", "A basic example", "v0.0.1")
 
 	// Set long description
-	cli.LongDescription("This app shows positional arguments")
+	cli.LongDescription("This app shows creating shortcuts for commands and flags")
 
 	// Name
 	var name string
@@ -22,7 +22,6 @@ func main() {
 	// Define action
 	cli.Action(func() error {
 		println("Your name is", name)
-		fmt.Printf("The remaining arguments were: %+v\n", cli.OtherArgs())
 		return nil
 	})
 	// Using a subcommand instead of a flag
@@ -30,7 +29,7 @@ func main() {
 	// CommandShortCut is used to set a shortcut for a command. Create a shortcut for "namecommand" that will be "nc"
 	nameCommand.CommandShortCut("nc")
 	nameCommand.Action(func() error {
-		fmt.Printf("The remaining arguments were: %+v\n", nameCommand.OtherArgs())
+		fmt.Println("The `namecommand` command was run!")
 		return nil
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/leaanthony/clir
 
 go 1.12
-
-replace github.com/leaanthony/clir => ../clir

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/leaanthony/clir
 
 go 1.12
+
+replace github.com/leaanthony/clir => ../clir


### PR DESCRIPTION
If you are interested I have implemented a "shortcut" function for commands and flags.

Essentially allow you define a main flag/shortcut as ("name") and then define a shortcut ("n"), and both will work when called from the command line.
There are two commands `FlagShortCut` and `CommandShortCut`

It works like this (for flags, same thing for commands):

```
        var name string
	nameFlag := cli.StringFlag("name", "Your name", &name)
	// FlagShort is used to set a shortcut for a flag. Create a shortcut for "-name", that will be "-n"
	nameFlag.FlagShortCut("name", "n")
```

Problems:
- User could in theory accidentally set a flag shortcut on a command and the other way around
- The print command for flags cannot show the shortcodes in the same interface unless we rip out the printdefaults from the standard library and implement it in the clir code.  We could also add another section after the flags with the shortcodes, but not the nicest way of doing it.
Update: Added a print function to print the shortcuts after the flags since that is the easiest way.
- The commands print has an extra space if no shortcode is set on the command, that is easy to fix with an if check if needed.