### PR TITLE
functional flag builder pattern

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -112,6 +112,13 @@ func (c *Cli) PostRun(callback func(*Cli) error) {
 	c.postRunCommand = callback
 }
 
+func (c *Cli) WithFlags(flags ...flagFunc) *Cli {
+	for _, f := range flags {
+		f(c.rootCommand)
+	}
+	return c
+}
+
 // BoolFlag - Adds a boolean flag to the root command.
 func (c *Cli) BoolFlag(name, description string, variable *bool) *Cli {
 	c.rootCommand.BoolFlag(name, description, variable)

--- a/cli.go
+++ b/cli.go
@@ -115,6 +115,7 @@ func (c *Cli) PostRun(callback func(*Cli) error) {
 func (c *Cli) WithFlags(flags ...flagFunc) *Cli {
 	for _, f := range flags {
 		f(c.rootCommand)
+		c.rootCommand.flagCount++
 	}
 	return c
 }

--- a/command.go
+++ b/command.go
@@ -56,7 +56,6 @@ func (c *Command) setParentCommandPath(parentCommandPath string) {
 	c.BoolFlag("help", "Get help on the '"+strings.ToLower(c.commandPath)+"' command.", &c.helpFlag)
 
 	// result.Flags.Usage = result.PrintHelp
-
 }
 
 func (c *Command) inheritFlags(inheritFlags *flag.FlagSet) {
@@ -115,7 +114,6 @@ func (c *Command) parseFlags(args []string) error {
 
 // Run - Runs the Command with the given arguments
 func (c *Command) run(args []string) error {
-
 	// If we have arguments, process them
 	if len(args) > 0 {
 		// Check for subcommand
@@ -644,6 +642,13 @@ func (c *Command) addSliceField(field reflect.Value, defaultValue, separator str
 		field.Set(reflect.ValueOf(defaultValues))
 	default:
 		panic(fmt.Sprintf("addSliceField() not supported slice type %s", t.Elem().Elem().Kind().String()))
+	}
+	return c
+}
+
+func (c *Command) WithFlags(flags ...flagFunc) *Command {
+	for _, f := range flags {
+		f(c)
 	}
 	return c
 }

--- a/command.go
+++ b/command.go
@@ -649,6 +649,7 @@ func (c *Command) addSliceField(field reflect.Value, defaultValue, separator str
 func (c *Command) WithFlags(flags ...flagFunc) *Command {
 	for _, f := range flags {
 		f(c)
+		c.flagCount++
 	}
 	return c
 }

--- a/flag.go
+++ b/flag.go
@@ -1,0 +1,171 @@
+package clir
+
+type flagFunc func(c *Command)
+
+func BoolFlag(name, description string, variable *bool) flagFunc {
+	return func(c *Command) {
+		c.flags.BoolVar(variable, name, *variable, description)
+	}
+}
+
+func BoolsFlag(name, description string, variable *[]bool) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newBoolsValue(*variable, variable), name, description)
+	}
+}
+
+func StringFlag(name, description string, variable *string) flagFunc {
+	return func(c *Command) {
+		c.flags.StringVar(variable, name, *variable, description)
+	}
+}
+
+func StringsFlag(name, description string, variable *[]string) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newStringsValue(*variable, variable), name, description)
+	}
+}
+
+func IntFlag(name, description string, variable *int) flagFunc {
+	return func(c *Command) {
+		c.flags.IntVar(variable, name, *variable, description)
+	}
+}
+
+func IntsFlag(name, description string, variable *[]int) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newIntsValue(*variable, variable), name, description)
+	}
+}
+
+func Int8Flag(name, description string, variable *int8) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newInt8Value(*variable, variable), name, description)
+	}
+}
+
+func Int8sFlag(name, description string, variable *[]int8) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newInt8sValue(*variable, variable), name, description)
+	}
+}
+
+func Int16Flag(name, description string, variable *int16) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newInt16Value(*variable, variable), name, description)
+	}
+}
+
+func Int16sFlag(name, description string, variable *[]int16) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newInt16sValue(*variable, variable), name, description)
+	}
+}
+
+func Int32Flag(name, description string, variable *int32) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newInt32Value(*variable, variable), name, description)
+	}
+}
+
+func Int32sFlag(name, description string, variable *[]int32) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newInt32sValue(*variable, variable), name, description)
+	}
+}
+
+func Int64Flag(name, description string, variable *int64) flagFunc {
+	return func(c *Command) {
+		c.flags.Int64Var(variable, name, *variable, description)
+	}
+}
+
+func Int64sFlag(name, description string, variable *[]int64) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newInt64sValue(*variable, variable), name, description)
+	}
+}
+
+func UintFlag(name, description string, variable *uint) flagFunc {
+	return func(c *Command) {
+		c.flags.UintVar(variable, name, *variable, description)
+	}
+}
+
+func UintsFlag(name, description string, variable *[]uint) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newUintsValue(*variable, variable), name, description)
+	}
+}
+
+func Uint8Flag(name, description string, variable *uint8) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newUint8Value(*variable, variable), name, description)
+	}
+}
+
+func Uint8sFlag(name, description string, variable *[]uint8) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newUint8sValue(*variable, variable), name, description)
+	}
+}
+
+func Uint16Flag(name, description string, variable *uint16) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newUint16Value(*variable, variable), name, description)
+	}
+}
+
+func Uint16sFlag(name, description string, variable *[]uint16) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newUint16sValue(*variable, variable), name, description)
+	}
+}
+
+func Uint32Flag(name, description string, variable *uint32) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newUint32Value(*variable, variable), name, description)
+	}
+}
+
+func Uint32sFlag(name, description string, variable *[]uint32) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newUint32sValue(*variable, variable), name, description)
+	}
+}
+
+func Uint64Flag(name, description string, variable *uint64) flagFunc {
+	return func(c *Command) {
+		c.flags.Uint64Var(variable, name, *variable, description)
+	}
+}
+
+func Uint64sFlag(name, description string, variable *[]uint64) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newUint64sValue(*variable, variable), name, description)
+	}
+}
+
+func Float64Flag(name, description string, variable *float64) flagFunc {
+	return func(c *Command) {
+		c.flags.Float64Var(variable, name, *variable, description)
+	}
+}
+
+func Float64sFlag(name, description string, variable *[]float64) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newFloat64sValue(*variable, variable), name, description)
+	}
+}
+
+func Float32Flag(name, description string, variable *float32) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newFloat32Value(*variable, variable), name, description)
+	}
+}
+
+func Float32sFlag(name, description string, variable *[]float32) flagFunc {
+	return func(c *Command) {
+		c.flags.Var(newFloat32sValue(*variable, variable), name, description)
+	}
+}


### PR DESCRIPTION
I've noticed that some flags aren't exposed by the cli/root command and that every time a new flag type is added, you have to wrap it.

https://github.com/leaanthony/clir/blob/9a039b715dd1887540158466bbd64a16c5e817ed/command.go#L820-L831

https://github.com/leaanthony/clir/blob/9a039b715dd1887540158466bbd64a16c5e817ed/cli.go#L115-L125


Using the functional paradigm, we can simplify to this:
```go
cli.WithFlags(
  clir.BoolFlag("name", "desc", &boolVar),
  clir.Float64Flag("lorum", "ipsum", &floatVar),
  ...
)
```

All the flag code is thus shared and you just have this in cli/command
```diff
diff --git a/cli.go b/cli.go
index 47a0849..ffc475c 100644
--- a/cli.go
+++ b/cli.go
@@ -112,6 +112,13 @@ func (c *Cli) PostRun(callback func(*Cli) error) {
    c.postRunCommand = callback
 }
 
+func (c *Cli) WithFlags(flags ...flagFunc) *Cli {
+   for _, f := range flags {
+       f(c.rootCommand)
+   }
+   return c
+}
+

diff --git a/command.go b/command.go
index 5ac8754..4a1282e 100644
--- a/command.go
+++ b/command.go
 
+func (c *Command) WithFlags(flags ...flagFunc) *Command {
+   for _, f := range flags {
+       f(c)
+   }
+   return c
+}
+
```