### PR TITLE
Bump GitHub workflow to latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
 
     - name: Set up Go 1.19
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.19
+        go-version: 1.22
       id: go
 
     - name: Check out code

--- a/cli.go
+++ b/cli.go
@@ -39,7 +39,7 @@ func (c *Cli) SetBannerFunction(fn func(*Cli) string) {
 
 // SetErrorFunction - Set custom error message when undefined
 // flags are used by the user. First argument is a string containing
-// the commnad path used. Second argument is the undefined flag error.
+// the command path used. Second argument is the undefined flag error.
 func (c *Cli) SetErrorFunction(fn func(string, error) error) {
 	c.errorHandler = fn
 }


### PR DESCRIPTION
This PR bumps GitHub action workflow to latest version, thus avoiding deprecation warnings as seen [here](https://github.com/leaanthony/clir/actions/runs/9016087006).